### PR TITLE
patch the 10 years check away

### DIFF
--- a/patches-10/Solaris11-10years.patch
+++ b/patches-10/Solaris11-10years.patch
@@ -1,0 +1,12 @@
+--- make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java.orig	2025-06-02 15:19:22.778297762 +0000
++++ make/jdk/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java	2025-06-02 15:19:34.717245341 +0000
+@@ -284,9 +284,6 @@
+             checkCurrencyCode(newCurrency);
+             String timeString = currencyInfo.substring(4, length - 4);
+             long time = format.parse(timeString).getTime();
+-            if (Math.abs(time - System.currentTimeMillis()) > ((long) 10) * 365 * 24 * 60 * 60 * 1000) {
+-                throw new RuntimeException("time is more than 10 years from present: " + time);
+-            }
+             specialCaseCutOverTimes[specialCaseCount] = time;
+             specialCaseOldCurrencies[specialCaseCount] = oldCurrency;
+             specialCaseOldCurrenciesDefaultFractionDigits[specialCaseCount] = getDefaultFractionDigits(oldCurrency);

--- a/patches-10/series
+++ b/patches-10/series
@@ -1,3 +1,4 @@
 Solaris11-EM_486.patch -p0
 Solaris11-TRAPNO.patch -p0
 Solaris11-caddr32.patch -p0
+Solaris11-10years.patch -p0

--- a/patches-9/Solaris11-10years.patch
+++ b/patches-9/Solaris11-10years.patch
@@ -1,0 +1,12 @@
+--- jdk/make/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java.orig	2025-06-02 15:08:19.382852914 +0000
++++ jdk/make/src/classes/build/tools/generatecurrencydata/GenerateCurrencyData.java	2025-06-02 15:08:33.983873597 +0000
+@@ -284,9 +284,6 @@
+             checkCurrencyCode(newCurrency);
+             String timeString = currencyInfo.substring(4, length - 4);
+             long time = format.parse(timeString).getTime();
+-            if (Math.abs(time - System.currentTimeMillis()) > ((long) 10) * 365 * 24 * 60 * 60 * 1000) {
+-                throw new RuntimeException("time is more than 10 years from present: " + time);
+-            }
+             specialCaseCutOverTimes[specialCaseCount] = time;
+             specialCaseOldCurrencies[specialCaseCount] = oldCurrency;
+             specialCaseOldCurrenciesDefaultFractionDigits[specialCaseCount] = getDefaultFractionDigits(oldCurrency);

--- a/patches-9/series
+++ b/patches-9/series
@@ -1,3 +1,4 @@
 Solaris11-EM_486.patch -p0
 Solaris11-TRAPNO.patch -p0
 Solaris11-caddr32.patch -p0
+Solaris11-10years.patch -p0


### PR DESCRIPTION
So much for making software buildable in the far (?) future. For the record Java 9 was released in 2017.